### PR TITLE
Enable replication manager to specify cortx and aws as targets for testing.

### DIFF
--- a/s3/replication/common/src/s3replicationcommon/job.py
+++ b/s3/replication/common/src/s3replicationcommon/job.py
@@ -283,10 +283,10 @@ class Job:
         return self._obj["target"]["endpoint"]
 
     def get_target_s3_service_name(self):
-        return self._obj["source"]["service_name"]
+        return self._obj["target"]["service_name"]
 
     def get_target_s3_region(self):
-        return self._obj["source"]["region"]
+        return self._obj["target"]["region"]
 
     def get_target_access_key(self):
         return self._obj["target"]["access_key"]

--- a/s3/replication/manager/README.md
+++ b/s3/replication/manager/README.md
@@ -64,3 +64,12 @@ To run specific test.
 py.test tests/system -k 'test_post_job[valid_job-201]'
 py.test tests/system -k 'test_post_subscriber[valid_payload-201]'
 ```
+
+For testing with cortx s3, following user defined attributes can be specified
+to simulate replication events.
+```sh
+s3cmd put --add-header x-amz-meta-replication:true \
+          --add-header x-amz-meta-target-site:awss3 \
+          --add-header x-amz-meta-target-bucket:targetbucket \
+          someobject.jpg s3://sourcebucket
+```

--- a/s3/replication/manager/README.md
+++ b/s3/replication/manager/README.md
@@ -43,10 +43,28 @@ Install the package.
 python3 setup.py install
 ```
 
+Replication manager currently provides ability to define target sites using
+following config files. These files needs to be updated to point to your test
+target sites. This is eventually be replaced using Bucket replication configuration
+from S3 server.
+
+Files to be modified.
+`~/.cortxs3/cortx_s3.yaml` and `~/.cortxs3/aws_s3.yaml`
+These can also be modified in source or use reference from source from
+`manager/src/config/` folder.
+
 Start the replicator.
 ```sh
 python3 -m s3replicationmanager
 ```
+
+Following sections specify how to test replication manager.
+Tests use some sample data, and one of the files used is
+`manager/tests/system/data/fdmi_test_job.json`
+
+Modify appropriate values to run a specific test. Most attributes are
+self explanatory. But `x-amz-meta-target-site` takes 2 different values
+as `cortxs3` for cortx target and `awss3` for aws s3 target.
 
 Run system tests after starting the Replication manager.
 ```sh

--- a/s3/replication/manager/src/config/aws_s3.yaml
+++ b/s3/replication/manager/src/config/aws_s3.yaml
@@ -1,0 +1,3 @@
+endpoint: "http://s3.amazonaws.com"
+s3_service_name: s3
+s3_region: us-east-1

--- a/s3/replication/manager/src/config/cortx_s3.yaml
+++ b/s3/replication/manager/src/config/cortx_s3.yaml
@@ -1,0 +1,3 @@
+endpoint: "http://s3.seagate.com:8090"
+s3_service_name: cortxs3
+s3_region: us-west2

--- a/s3/replication/manager/src/config/cortx_s3.yaml
+++ b/s3/replication/manager/src/config/cortx_s3.yaml
@@ -1,3 +1,3 @@
-endpoint: "http://s3.seagate.com:8090"
+endpoint: "http://s3.seagate.com"
 s3_service_name: cortxs3
 s3_region: us-west2

--- a/s3/replication/manager/src/config/source_target_s3_config.yaml
+++ b/s3/replication/manager/src/config/source_target_s3_config.yaml
@@ -1,4 +1,0 @@
-endpoint: "http://s3.seagate.com"
-s3_service_name: cortxs3
-s3_region: us-west2
-target_bucket_name: targetbucket

--- a/s3/replication/manager/src/s3replicationmanager/job_routes.py
+++ b/s3/replication/manager/src/s3replicationmanager/job_routes.py
@@ -39,6 +39,10 @@ async def add_job(request):
 
     job_record = PrepareReplicationJob.from_fdmi(fdmi_job)
 
+    if job_record is None:
+        return web.json_response(
+            {'ErrorResponse': 'BadRequest. Invalid Job!'}, status=400)
+
     job = request.app['all_jobs'].add_job_using_json(job_record)
     _logger.debug('Successfully added Job with job_id : {} '.
                   format(job.get_job_id()))

--- a/s3/replication/manager/src/s3replicationmanager/prepare_job.py
+++ b/s3/replication/manager/src/s3replicationmanager/prepare_job.py
@@ -41,20 +41,26 @@ class PrepareReplicationJob:
 
         # Read the config file for source/target sites.
         cortx_s3 = None
-        with open(os.path.join(
-                os.path.dirname(__file__), '..',
-                'config/cortx_s3.yaml'), 'r') as cortx_s3_f:
+        conf_path = os.path.join(os.path.expanduser('~'), '.cortxs3')
+        file_path = os.path.join(conf_path, "cortx_s3.yaml")
+        if not os.path.isfile(file_path):
+            file_path = os.path.join(
+                os.path.dirname(__file__), '..', 'config/cortx_s3.yaml')
+
+        with open(file_path, 'r') as cortx_s3_f:
             cortx_s3 = yaml.safe_load(cortx_s3_f)
 
         aws_s3 = None
-        with open(os.path.join(
-                os.path.dirname(__file__), '..',
-                'config/aws_s3.yaml'), 'r') as aws_s3_f:
+        file_path = os.path.join(conf_path, "aws_s3.yaml")
+        if not os.path.isfile(file_path):
+            file_path = os.path.join(
+                os.path.dirname(__file__), '..', 'config/aws_s3.yaml')
+
+        with open(file_path, 'r') as aws_s3_f:
             aws_s3 = yaml.safe_load(aws_s3_f)
 
         # File with credentials. ~/.cortxs3/credentials.yaml
-        cortx_creds_home = os.path.join(os.path.expanduser('~'), '.cortxs3')
-        cortx_creds_path = os.path.join(cortx_creds_home, 'credentials.yaml')
+        cortx_creds_path = os.path.join(conf_path, 'credentials.yaml')
 
         cortx_credentials = None
         with open(cortx_creds_path, 'r') as cred_config:

--- a/s3/replication/manager/src/s3replicationmanager/prepare_job.py
+++ b/s3/replication/manager/src/s3replicationmanager/prepare_job.py
@@ -26,6 +26,7 @@ import datetime
 import os
 import yaml
 
+from configparser import ConfigParser
 from s3replicationcommon.templates import replication_job_template
 
 
@@ -35,19 +36,37 @@ class PrepareReplicationJob:
     def from_fdmi(fdmi_record):
         """Prepare replication job record from fdmi record."""
 
-        # Read the config file.
+        # XXX All below, source/target credentials logic to change after
+        # S3 server changes are ready for setting up replication.
+
+        # Read the config file for source/target sites.
+        cortx_s3 = None
         with open(os.path.join(
                 os.path.dirname(__file__), '..',
-                'config/source_target_s3_config.yaml'), 'r') as config:
-            config = yaml.safe_load(config)
+                'config/cortx_s3.yaml'), 'r') as cortx_s3_f:
+            cortx_s3 = yaml.safe_load(cortx_s3_f)
+
+        aws_s3 = None
+        with open(os.path.join(
+                os.path.dirname(__file__), '..',
+                'config/aws_s3.yaml'), 'r') as aws_s3_f:
+            aws_s3 = yaml.safe_load(aws_s3_f)
 
         # File with credentials. ~/.cortxs3/credentials.yaml
-        creds_home = os.path.join(os.path.expanduser('~'), '.cortxs3')
-        creds_file_path = os.path.join(creds_home, 'credentials.yaml')
+        cortx_creds_home = os.path.join(os.path.expanduser('~'), '.cortxs3')
+        cortx_creds_path = os.path.join(cortx_creds_home, 'credentials.yaml')
 
-        credentials_config = None
-        with open(creds_file_path, 'r') as cred_config:
-            credentials_config = yaml.safe_load(cred_config)
+        cortx_credentials = None
+        with open(cortx_creds_path, 'r') as cred_config:
+            cortx_credentials = yaml.safe_load(cred_config)
+
+        # For AWS target.
+        # File with credentials. ~/.aws/credentials
+        aws_s3_creds_home = os.path.join(os.path.expanduser('~'), '.aws')
+        aws_s3_creds_path = os.path.join(aws_s3_creds_home, 'credentials')
+
+        aws_s3_credentials = ConfigParser()
+        aws_s3_credentials.read(aws_s3_creds_path)
 
         job_dict = replication_job_template()
 
@@ -61,12 +80,12 @@ class PrepareReplicationJob:
         job_dict["replication-event-create-time"] = epoch_t.strftime(
             '%Y%m%dT%H%M%SZ')
 
-        job_dict["source"]["endpoint"] = config["endpoint"]
-        job_dict["source"]["service_name"] = config["s3_service_name"]
-        job_dict["source"]["region"] = config["s3_region"]
+        job_dict["source"]["endpoint"] = cortx_s3["endpoint"]
+        job_dict["source"]["service_name"] = cortx_s3["s3_service_name"]
+        job_dict["source"]["region"] = cortx_s3["s3_region"]
 
-        job_dict["source"]["access_key"] = credentials_config["access_key"]
-        job_dict["source"]["secret_key"] = credentials_config["secret_key"]
+        job_dict["source"]["access_key"] = cortx_credentials["access_key"]
+        job_dict["source"]["secret_key"] = cortx_credentials["secret_key"]
 
         job_dict["source"]["operation"]["attributes"]["Bucket-Name"] = \
             fdmi_record["Bucket-Name"]
@@ -95,12 +114,24 @@ class PrepareReplicationJob:
         job_dict["source"]["operation"]["attributes"]["x-amz-version-id"] = \
             fdmi_record["System-Defined"]["x-amz-version-id"]
 
-        job_dict["target"]["endpoint"] = config["endpoint"]
-        job_dict["target"]["service_name"] = config["s3_service_name"]
-        job_dict["target"]["region"] = config["s3_region"]
-        job_dict["target"]["access_key"] = credentials_config["access_key"]
-        job_dict["target"]["secret_key"] = credentials_config["secret_key"]
+        # XXX: Change after S3 changes are ready for replication.
+        if fdmi_record["User-Defined"]["x-amz-meta-target-site"] == "cortxs3":
+            job_dict["target"]["endpoint"] = cortx_s3["endpoint"]
+            job_dict["target"]["service_name"] = cortx_s3["s3_service_name"]
+            job_dict["target"]["region"] = cortx_s3["s3_region"]
+            job_dict["target"]["access_key"] = cortx_credentials["access_key"]
+            job_dict["target"]["secret_key"] = cortx_credentials["secret_key"]
+        elif fdmi_record["User-Defined"]["x-amz-meta-target-site"] == "awss3":
+            job_dict["target"]["endpoint"] = aws_s3["endpoint"]
+            job_dict["target"]["service_name"] = aws_s3["s3_service_name"]
+            job_dict["target"]["region"] = aws_s3["s3_region"]
+            job_dict["target"]["access_key"] = aws_s3_credentials["access_key"]
+            job_dict["target"]["secret_key"] = aws_s3_credentials["secret_key"]
+        else:
+            # Invalid record.
+            return None
 
-        job_dict["target"]["Bucket-Name"] = config["target_bucket_name"]
+        job_dict["target"]["Bucket-Name"] = \
+            fdmi_record["User-Defined"]["x-amz-meta-target-bucket"]
 
         return job_dict

--- a/s3/replication/manager/src/s3replicationmanager/prepare_job.py
+++ b/s3/replication/manager/src/s3replicationmanager/prepare_job.py
@@ -125,8 +125,10 @@ class PrepareReplicationJob:
             job_dict["target"]["endpoint"] = aws_s3["endpoint"]
             job_dict["target"]["service_name"] = aws_s3["s3_service_name"]
             job_dict["target"]["region"] = aws_s3["s3_region"]
-            job_dict["target"]["access_key"] = aws_s3_credentials["access_key"]
-            job_dict["target"]["secret_key"] = aws_s3_credentials["secret_key"]
+            job_dict["target"]["access_key"] = \
+                aws_s3_credentials["default"]["aws_access_key_id"]
+            job_dict["target"]["secret_key"] = \
+                aws_s3_credentials["default"]["aws_secret_access_key"]
         else:
             # Invalid record.
             return None

--- a/s3/replication/manager/tests/system/data/fdmi_test_job.json
+++ b/s3/replication/manager/tests/system/data/fdmi_test_job.json
@@ -1,11 +1,11 @@
 {
   "ACL": "base64-encoded-acl-json",
-  "Bucket-Name": "seagatebucket",
-  "Object-Name": "seagate-hdd.jpg",
-  "Object-URI": "seagatebucket\\\\seagate-hdd.jpg",
+  "Bucket-Name": "sourcebucket",
+  "Object-Name": "test_object_0_sz1223",
+  "Object-URI": "sourcebucket\\\\test_object_0_sz1223",
   "System-Defined": {
-    "Content-Length": "0",
-    "Content-MD5": "d41d8cd98f00b204e9800998ecf8427e",
+    "Content-Length": "1223",
+    "Content-MD5": "6a7ef642e08c2ca64ac644d3ed7b847d",
     "Content-Type": "",
     "Date": "2021-05-05T08:10:14.000Z",
     "Last-Modified": "2021-05-05T08:10:14.000Z",
@@ -22,6 +22,11 @@
     "x-amz-storage-class": "STANDARD",
     "x-amz-version-id": "MTg0NDY3NDI0NTM1MDczNDEwMjU",
     "x-amz-website-redirect-location": "None"
+  },
+  "User-Defined": {
+    "x-amz-meta-replication": "true",
+    "x-amz-meta-target-site": "cortxs3",
+    "x-amz-meta-target-bucket": "targetbucket"
   },
   "create_timestamp": "2021-05-05T08:10:15.000Z",
   "layout_id": 1,


### PR DESCRIPTION
Enable replication manager to specify cortx and aws as targets for testing.

-----
[View rendered s3/replication/manager/README.md](https://github.com/kaustubh-d/cortx-multisite/blob/kd/targets/s3/replication/manager/README.md)