### PR TITLE
Change asyncio create_task to ensure_future for python 36 compatibility

### DIFF
--- a/s3/replication/common/src/s3replicationcommon/jobs.py
+++ b/s3/replication/common/src/s3replicationcommon/jobs.py
@@ -246,7 +246,7 @@ class Jobs:
         self._jobs_queued[job.get_replication_id()] = None
 
         if self._timeout is not None:
-            asyncio.create_task(
+            asyncio.ensure_future(
                 self.schedule_clear_cache(job.get_job_id())
             )
         return True

--- a/s3/replication/manager/src/s3replicationmanager/distributor.py
+++ b/s3/replication/manager/src/s3replicationmanager/distributor.py
@@ -101,7 +101,7 @@ class JobDistributor:
                     replicator_client = ReplicatorClient(subscriber)
 
                     # Schedule async job send using http POST.
-                    task = asyncio.create_task(replicator_client.post(
+                    task = asyncio.ensure_future(replicator_client.post(
                         jobs_to_send))
                     task_list.append(task)
                     jobs_list_per_task.append(jobs_to_send)

--- a/s3/replication/replicator/tests/system/load_transfer_test.py
+++ b/s3/replication/replicator/tests/system/load_transfer_test.py
@@ -195,7 +195,7 @@ async def setup_source(session, bucket_name, transfer_chunk_size):
         object_name = "test_object_" + str(i) + "_sz" + str(object_size)
 
         # Perform the PUT operation on source and capture md5.
-        task = asyncio.create_task(
+        task = asyncio.ensure_future(
             async_put_object(session, bucket_name, object_name,
                              object_size, transfer_chunk_size))
         put_task_list.append(task)
@@ -242,7 +242,7 @@ async def run_load_test():
             s3_config, object_info)
         replication_jobs = [replication_job]
         logger.debug("POST {}/jobs {}".format(url, replication_jobs))
-        transfer_task = asyncio.create_task(replicator_session.post(
+        transfer_task = asyncio.ensure_future(replicator_session.post(
             url + '/jobs', json=replication_jobs))
         transfer_task_list.append(transfer_task)
     # jobs info contains list of response from POST /jobs for each transfer
@@ -273,7 +273,7 @@ async def run_load_test():
             logger.debug(
                 "Checking status for job: job_id= {}".format(job_id))
 
-            job_status_task = asyncio.create_task(replicator_session.get(
+            job_status_task = asyncio.ensure_future(replicator_session.get(
                 url + '/jobs/' + job_id))
             job_status_task_list.append(job_status_task)
 


### PR DESCRIPTION
Change asyncio.create_task to asyncio.ensure_future for python 36 compatibility.

Signed-off-by: kaustubh-d <2116373+kaustubh-d@users.noreply.github.com>