### PR TITLE
Change asyncio.create_task to asyncio.ensure_future for py36 compatibility

### DIFF
--- a/s3/replication/manager/src/s3replicationmanager/app.py
+++ b/s3/replication/manager/src/s3replicationmanager/app.py
@@ -36,7 +36,7 @@ async def on_startup(app):
 
     distributor = JobDistributor(app)
     app["job_distributor"] = distributor
-    asyncio.create_task(distributor.start())
+    asyncio.ensure_future(distributor.start())
 
 
 async def on_shutdown(app):


### PR DESCRIPTION
Change asyncio.create_task to asyncio.ensure_future for py36 compatibility

Signed-off-by: kaustubh-d <2116373+kaustubh-d@users.noreply.github.com>