### PR TITLE
Added jobs' count query support for replicator

### DIFF
--- a/s3/replication/common/src/s3replicationcommon/jobs.py
+++ b/s3/replication/common/src/s3replicationcommon/jobs.py
@@ -202,6 +202,15 @@ class Jobs:
         """
         return len(self._jobs_queued)
 
+    def inprogress_count(self):
+        """
+        Returns in-progress jobs in collection.
+
+        Returns:
+            int: Count of jobs in collection.
+        """
+        return len(self._jobs_inprogress)
+
     def is_job_present(self, replication_id):
         """
         Checks if given replication id is present.

--- a/s3/replication/common/src/s3replicationcommon/jobs.py
+++ b/s3/replication/common/src/s3replicationcommon/jobs.py
@@ -207,7 +207,7 @@ class Jobs:
         Returns in-progress jobs in collection.
 
         Returns:
-            int: Count of jobs in collection.
+            int: Count of in-progress jobs in collection.
         """
         return len(self._jobs_inprogress)
 

--- a/s3/replication/manager/src/s3replicationmanager/job_routes.py
+++ b/s3/replication/manager/src/s3replicationmanager/job_routes.py
@@ -146,8 +146,7 @@ async def get_jobs(request):
         _logger.debug('Returning all jobs count = {}'.format(
             all_jobs_list.count()))
         return web.json_response(
-            {'count': all_jobs_list.count() + all_jobs_list.count()},
-            status=200)
+            {'count': all_jobs_list.count()}, status=200)
 
     else:
         # return jobs that are not yet distributed.

--- a/s3/replication/manager/tests/system/load_transfer_test.py
+++ b/s3/replication/manager/tests/system/load_transfer_test.py
@@ -43,7 +43,6 @@ from s3replicationmanager.config import Config as ManagerConfig
 from s3_config import S3Config
 
 
-
 class TestConfig:
     """Configuration for load transfer test."""
 

--- a/s3/replication/replicator/src/s3replicator/replicator_routes.py
+++ b/s3/replication/replicator/src/s3replicator/replicator_routes.py
@@ -46,13 +46,13 @@ async def list_jobs(request):
 
     if 'count' in query:
         if 'inprogress' in query:
-            return web.json_response({'In-progress jobs count':
+            return web.json_response({'inprogress-count':
                                   jobs.inprogress_count()}, status=200)
         elif 'completed' in query:
-            return web.json_response({'Completed jobs count':
+            return web.json_response({'completed-count':
                                   completed_jobs.count()}, status=200)
         else:
-            return web.json_response({'All jobs count': jobs.count()}, status=200)
+            return web.json_response({'count': jobs.count()}, status=200)
     else:
         _logger.debug('Total replication jobs {}'.format(jobs.count()))
         return web.json_response(jobs, dumps=Jobs.dumps, status=200)

--- a/s3/replication/replicator/src/s3replicator/replicator_routes.py
+++ b/s3/replication/replicator/src/s3replicator/replicator_routes.py
@@ -44,14 +44,15 @@ async def list_jobs(request):
     jobs = request.app['all_jobs']
     completed_jobs = request.app['completed_jobs']
 
-    if all(q in query for q in ['count', 'inprogress']):
-        return web.json_response({'In-progress jobs count':
+    if 'count' in query:
+        if 'inprogress' in query:
+            return web.json_response({'In-progress jobs count':
                                   jobs.inprogress_count()}, status=200)
-    elif all(q in query for q in ['count', 'completed']):
-        return web.json_response({'Completed jobs count':
+        elif 'completed' in query:
+            return web.json_response({'Completed jobs count':
                                   completed_jobs.count()}, status=200)
-    elif 'count' in query:
-        return web.json_response({'All jobs count': jobs.count()}, status=200)
+        else:
+            return web.json_response({'All jobs count': jobs.count()}, status=200)
     else:
         _logger.debug('Total replication jobs {}'.format(jobs.count()))
         return web.json_response(jobs, dumps=Jobs.dumps, status=200)

--- a/s3/replication/replicator/src/s3replicator/replicator_routes.py
+++ b/s3/replication/replicator/src/s3replicator/replicator_routes.py
@@ -39,17 +39,21 @@ async def list_jobs(request):
     url = request.path_qs
     url_ob = urlparse(url)
     query = parse_qs(url_ob.query, keep_blank_values=True)
+    _logger.debug('API: GET /jobs\n Query: {}'.format(query))
 
-    _logger.debug('API: GET /jobs')
     jobs = request.app['all_jobs']
     completed_jobs = request.app['completed_jobs']
 
-    if 'all' in query:
-        return web.json_response({'count': jobs.count()}, status=200)
-    elif 'completed' in query:
-        return web.json_response({'count': completed_jobs.count()}, status=200)
+    if all(q in query for q in ['count', 'inprogress']):
+        return web.json_response({'In-progress jobs count':
+                                  jobs.inprogress_count()}, status=200)
+    elif all(q in query for q in ['count', 'completed']):
+        return web.json_response({'Completed jobs count':
+                                  completed_jobs.count()}, status=200)
+    elif 'count' in query:
+        return web.json_response({'All jobs count': jobs.count()}, status=200)
     else:
-        _logger.debug('Number of jobs in-progress {}'.format(jobs.count()))
+        _logger.debug('Total replication jobs {}'.format(jobs.count()))
         return web.json_response(jobs, dumps=Jobs.dumps, status=200)
 
 


### PR DESCRIPTION
* Add 'all' jobs count and 'completed' jobs count params
* Fix count query for replication manager

Signed-off-by: Rajkumar Patel <rajkumar.patel@seagate.com>