### PR TITLE
Add support for multiple tags in s3-put-object-tagging API

### DIFF
--- a/s3/replication/common/experiments/s3_put_object_tagging.py
+++ b/s3/replication/common/experiments/s3_put_object_tagging.py
@@ -18,7 +18,6 @@
 # For any questions about this software or licensing,
 # please email opensource@seagate.com or cortx-questions@seagate.com.
 
-from config import Config
 import aiohttp
 import asyncio
 import fileinput
@@ -30,15 +29,15 @@ from os.path import abspath, join, dirname
 from s3replicationcommon.aws_v4_signer import AWSV4Signer
 
 # Import config module from '../tests/system'
-sys.path.append(abspath(join(dirname(__file__), '..', 'tests', 'system')))
-
+sys.path.append(abspath(join(dirname(__file__),'..','tests', 'system')))
+from config import Config
 
 async def main():
     async with aiohttp.ClientSession() as session:
         config = Config()
 
         bucket_name = config.source_bucket_name
-        object_name = config.object_name_prefix  # + "test"
+        object_name = config.object_name_prefix #+ "test"
         tag_name = config.object_tag_name
         tag_value = config.object_tag_value
 
@@ -62,7 +61,7 @@ async def main():
         os.system('cat tagset.xml')
 
         # open a file and read the tagset
-        file = os.open('tagset.xml', os.O_RDONLY)
+        file = os.open('tagset.xml',os.O_RDONLY)
         tagset = os.read(file, os.path.getsize(file))
 
         headers = AWSV4Signer(
@@ -83,7 +82,7 @@ async def main():
         print('PUT on {}'.format(config.endpoint + request_uri))
 
         async with session.put(config.endpoint + request_uri,
-                               data=tagset, params=query_params, headers=headers) as resp:
+            data=tagset, params=query_params, headers=headers) as resp:
             http_status = resp.status
             print("Response of PUT request {} ".format(resp))
 

--- a/s3/replication/common/tests/system/test_put_object_tagging.py
+++ b/s3/replication/common/tests/system/test_put_object_tagging.py
@@ -53,12 +53,15 @@ async def main():
     request_id = "dummy-request-id"
 
     # Get tag-name and tag-value from config
+    tagset = {}
+
     tag_name = config.object_tag_name
     tag_value = config.object_tag_value
+    tagset[tag_name]=tag_value
 
     tag_object = S3AsyncPutObjectTagging(session, request_id,
                                          bucket_name, object_name,
-                                         tag_name, tag_value)
+                                         tagset)
 
     await tag_object.send()
 

--- a/s3/replication/manager/tests/system/tag_transfer_test.py
+++ b/s3/replication/manager/tests/system/tag_transfer_test.py
@@ -98,12 +98,12 @@ def create_job_with_fdmi_record(s3_config, test_config, object_info):
     return job_dict
 
 
-async def async_put_object_tagging(session, bucket_name, object_name, tag_name, tag_value):
+async def async_put_object_tagging(session, bucket_name, object_name, tag_set):
 
     request_id = str(uuid.uuid4())
 
     obj = S3AsyncPutObjectTagging(session, request_id, bucket_name,
-                                  object_name, tag_name, tag_value)
+                                  object_name, tag_set)
 
     await obj.send()
 
@@ -129,14 +129,20 @@ async def setup_source(session, test_config):
                 test_config.min_obj_size,
                 test_config.max_obj_size)
 
+        tagset = {}
+
         # Generate object name
         object_name = "test_object_" + str(i) + "_sz" + str(object_size)
-        tag_name = "user-tag-" + str(i)
-        tag_value = "tag-value-" + str(i)
+
+        # Adding 2 exmaple tags to tagset to replicate
+        for i in range(2):
+            tag_name = object_name + "-tag-" + str(i)
+            tag_value = object_name + "-value-" + str(i)
+            tagset[tag_name]=tag_value
 
         # Perform the PUT operation on source and capture md5.
         task = asyncio.ensure_future(
-            async_put_object_tagging(session, test_config.source_bucket, object_name, tag_name, tag_value))
+            async_put_object_tagging(session, test_config.source_bucket, object_name, tagset))
         put_task_list.append(task)
     objects_info = await asyncio.gather(*put_task_list)
     return objects_info

--- a/s3/replication/replicator/src/s3replicator/object_tag_replicator.py
+++ b/s3/replication/replicator/src/s3replicator/object_tag_replicator.py
@@ -78,7 +78,7 @@ class ObjectTagReplicator:
             self._request_id,
             self._target_bucket,
             self._target_object,
-            list(self._tags.keys())[0], list(self._tags.values())[0])
+            self._tags)
 
         self._timer.start()
         await object_tag_writer.send()


### PR DESCRIPTION

- s3_put_object_tagging api now supports multiple tags
or a tagset put
- Change tag transfer test to support multiple tags' replication.
- Change test_put_object_tagging.py(API test file).

Signed-off-by: Rajkumar Patel <rajkumar.patel@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
