### PR TITLE
Add support for updating x-amz-replication-status on source objects

### DIFF
--- a/s3/replication/common/src/s3replicationcommon/job.py
+++ b/s3/replication/common/src/s3replicationcommon/job.py
@@ -119,6 +119,8 @@ class Job:
             assert self.get_source_object_size() is not None
 
             assert self.get_source_endpoint() is not None
+            #XXX Will be mandatory after service account integration
+            #assert self.get_source_admin_endpoint() is not None
             assert self.get_source_s3_service_name() is not None
             assert self.get_source_s3_region() is not None
 
@@ -254,7 +256,8 @@ class Job:
         """
         return S3Site(self.get_source_endpoint(),
                       self.get_source_s3_service_name(),
-                      self.get_source_s3_region())
+                      self.get_source_s3_region(),
+                      self.get_source_admin_endpoint())
 
     def get_source_bucket_name(self):
         """
@@ -273,6 +276,12 @@ class Job:
 
     def get_source_endpoint(self):
         return self._obj["source"]["endpoint"]
+
+    def get_source_admin_endpoint(self):
+        try:
+            return self._obj["source"]["admin_endpoint"]
+        except KeyError:
+            return None
 
     def get_source_s3_service_name(self):
         return self._obj["source"]["service_name"]

--- a/s3/replication/common/src/s3replicationcommon/job.py
+++ b/s3/replication/common/src/s3replicationcommon/job.py
@@ -119,8 +119,9 @@ class Job:
             assert self.get_source_object_size() is not None
 
             assert self.get_source_endpoint() is not None
-            #XXX Will be mandatory after service account integration
-            #assert self.get_source_admin_endpoint() is not None
+            # XXX Will be mandatory after service account integration
+            # assert self.get_source_admin_endpoint() is not None
+            # assert self.get_source_owner_account_id() is not None
             assert self.get_source_s3_service_name() is not None
             assert self.get_source_s3_region() is not None
 
@@ -273,6 +274,10 @@ class Job:
 
     def get_source_object_size(self):
         return self._obj["source"]["operation"]["attributes"]["Content-Length"]
+
+    def get_source_owner_account_id(self):
+        return self._obj["source"]["operation"][
+            "attributes"]["Owner-Account-id"]
 
     def get_source_endpoint(self):
         return self._obj["source"]["endpoint"]

--- a/s3/replication/common/src/s3replicationcommon/s3_session.py
+++ b/s3/replication/common/src/s3replicationcommon/s3_session.py
@@ -26,6 +26,7 @@ class S3Session:
         """Initialise S3 session."""
         self.logger = logger
         self.endpoint = s3_site.endpoint
+        self.admin_endpoint = s3_site.admin_endpoint
         self.service_name = s3_site.service_name
         self.region = s3_site.region
 

--- a/s3/replication/common/src/s3replicationcommon/s3_site.py
+++ b/s3/replication/common/src/s3replicationcommon/s3_site.py
@@ -21,11 +21,12 @@ from urllib.parse import urlparse
 
 
 class S3Site:
-    def __init__(self, endpoint, service_name, region):
+    def __init__(self, endpoint, service_name, region, admin_endpoint=None):
         """Initialise S3 session."""
         self.endpoint = endpoint
         self.service_name = service_name
         self.region = region
+        self.admin_endpoint = admin_endpoint
 
     def get_netloc(self):
         return urlparse(self.endpoint).netloc

--- a/s3/replication/common/src/s3replicationcommon/s3_update_replication_status.py
+++ b/s3/replication/common/src/s3replicationcommon/s3_update_replication_status.py
@@ -1,0 +1,238 @@
+#
+# Copyright (c) 2021 Seagate Technology LLC and/or its Affiliates
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# For any questions about this software or licensing,
+# please email opensource@seagate.com or cortx-questions@seagate.com.
+#
+import aiohttp
+import sys
+import json
+import base64
+from s3replicationcommon.s3_common import S3RequestState
+from s3replicationcommon.timer import Timer
+from s3replicationcommon.aws_v4_signer import AWSV4Signer
+from s3replicationcommon.log import fmt_reqid_log
+
+
+class S3AsyncUpdatereplicationStatus:
+    def __init__(self, session, request_id,
+                 bucket_name, object_name):
+        """Initialise."""
+        self._session = session
+        # Request id for better logging.
+        self._request_id = request_id
+        self._logger = session.logger
+
+        self._bucket_name = bucket_name
+        self._object_name = object_name
+
+        self.remote_down = False
+        self._http_status = None
+
+        self._timer = Timer()
+        self._state = S3RequestState.INITIALISED
+
+        self.global_bucket_index_id = "AAAAAAAAAHg=-AQAQAAAAAAA="
+        self.bucket_metadata_index_id = "AAAAAAAAAHg=-AgAQAAAAAAA="
+
+    def get_state(self):
+        """Returns current request state."""
+        return self._state
+
+    def get_execution_time(self):
+        """Return total time for HEAD Object operation."""
+        return self._timer.elapsed_time_ms()
+
+    def kv_session(self, index, key, value=None):
+        request_uri = '/indexes/{}/{}'.format(index, key)
+        full_uri = self._session.admin_endpoint + request_uri
+
+        query_params = ""
+        body = value or ""
+        headers = AWSV4Signer(
+            self._session.admin_endpoint,
+            self._session.service_name,
+            self._session.region,
+            self._session.access_key,
+            self._session.secret_key).prepare_signed_header(
+            'GET' if value is None else 'PUT',
+            request_uri,
+            query_params,
+            body
+        )
+
+        if (headers['Authorization'] is None):
+            self._logger.error(fmt_reqid_log(self._request_id) +
+                               "Failed to generate v4 signature")
+            sys.exit(-1)
+
+        self._logger.info(fmt_reqid_log(self._request_id) +
+                          'Motr index operation on {} {}'.format(
+                              full_uri, body))
+
+        if value is None:
+            return self._session.get_client_session().get(
+                full_uri,
+                params=query_params, headers=headers)
+        else:
+            return self._session.get_client_session().put(
+                full_uri,
+                params=query_params, headers=headers,
+                data=body.encode())
+
+    async def update(self, status):
+        self._timer.start()
+        self._state = S3RequestState.RUNNING
+
+        try:
+            if self._session.admin_endpoint is None:
+                self._logger.warn(fmt_reqid_log(self._request_id)
+                                  + 'Admin API not configured, '
+                                  + 'skipping source metadata update')
+                self._state = S3RequestState.COMPLETED
+                return
+
+            async with self.kv_session(
+                    self.global_bucket_index_id,
+                    self._bucket_name) as resp:
+
+                if resp.status == 200:
+                    bucket_info = json.loads(await resp.text())
+                    self._logger.info(fmt_reqid_log(self._request_id) +
+                                      'Bucket index lookup for {}'.
+                                      format(self._bucket_name) +
+                                      'response received with' +
+                                      ' status code: {}'.
+                                      format(resp.status))
+                    self._logger.debug(
+                        'bucket info: {}'.format(bucket_info))
+
+                else:
+                    self._state = S3RequestState.FAILED
+                    error_msg = await resp.text()
+                    self._logger.error(
+                        fmt_reqid_log(self._request_id) +
+                        'Index operation failed with http status: {}'.
+                        format(resp.status) +
+                        ' Error Response: {}'.format(error_msg))
+                    return
+
+            bucket_owner = bucket_info['account_id']
+
+            async with self.kv_session(
+                    self.bucket_metadata_index_id,
+                    bucket_owner + '/' + self._bucket_name) as resp:
+
+                if resp.status == 200:
+                    bucket_metadata = json.loads(await resp.text())
+
+                    self._logger.info(fmt_reqid_log(self._request_id) +
+                                      'Bucket index lookup for {} response'.
+                                      format(self._bucket_name) +
+                                      ' received with status code: {}'.
+                                      format(resp.status))
+                    self._logger.debug(
+                        'bucket metadata: {}'.format(bucket_metadata))
+
+                else:
+                    self._state = S3RequestState.FAILED
+                    error_msg = await resp.text()
+                    self._logger.error(
+                        fmt_reqid_log(self._request_id) +
+                        'Index operation failed with http status: {}'.
+                        format(resp.status) +
+                        ' Error Response: {}'.format(error_msg))
+                    return
+
+            layout = base64.b64decode(
+                    bucket_metadata['motr_object_list_index_layout'])
+            id_hi = base64.b64encode(layout[0:8]).decode()
+            id_lo = base64.b64encode(layout[8:16]).decode()
+            metadata_index = id_hi + '-' + id_lo
+
+            async with self.kv_session(
+                    metadata_index,
+                    self._object_name) as resp:
+
+                if resp.status == 200:
+                    object_metadata = json.loads(await resp.text())
+                    self._logger.info(fmt_reqid_log(self._request_id) +
+                                      'Object index lookup for {} in {}'.
+                                      format(self._object_name,
+                                             metadata_index) +
+                                      ' response received with' +
+                                      ' status code: {}'.
+                                      format(resp.status))
+                    self._logger.debug(
+                        'object metadata: {}'.format(object_metadata))
+
+                else:
+                    self._state = S3RequestState.FAILED
+                    error_msg = await resp.text()
+                    self._logger.error(
+                        fmt_reqid_log(self._request_id) +
+                        'Index operation failed with http status: {}'.
+                        format(resp.status) +
+                        ' Error Response: {}'.format(error_msg))
+                    return
+
+            object_metadata['x-amz-replication-status'] = status
+
+            async with self.kv_session(
+                    metadata_index,
+                    self._object_name,
+                    json.dumps(object_metadata)) as resp:
+
+                if resp.status == 200:
+                    self._logger.info(fmt_reqid_log(self._request_id) +
+                                      'Set x-amz-replication-status for ' +
+                                      '{} to {}, response received with'.
+                                      format(self._object_name, status) +
+                                      ' status code: {}'.
+                                      format(resp.status))
+                    self._logger.debug(
+                        'updated object metadata: {}'.format(object_metadata))
+
+                else:
+                    self._state = S3RequestState.FAILED
+                    error_msg = await resp.text()
+                    self._logger.error(
+                        fmt_reqid_log(self._request_id) +
+                        'Index operation failed with http status: {}'.
+                        format(resp.status) +
+                        ' Error Response: {}'.format(error_msg))
+                    return
+
+            self._state = S3RequestState.COMPLETED
+
+        except aiohttp.client_exceptions.ClientConnectorError as e:
+            self.remote_down = True
+            self._state = S3RequestState.FAILED
+            self._logger.error(fmt_reqid_log(self._request_id) +
+                               "Failed to connect to S3: " + str(e))
+        finally:
+            self._timer.stop()
+
+    def pause(self):
+        self._state = S3RequestState.PAUSED
+        # XXX Take real pause action
+
+    def resume(self):
+        self._state = S3RequestState.PAUSED
+        # XXX Take real resume action
+
+    def abort(self):
+        self._state = S3RequestState.ABORTED
+        # XXX Take abort pause action

--- a/s3/replication/manager/src/config/cortx_s3.yaml
+++ b/s3/replication/manager/src/config/cortx_s3.yaml
@@ -1,3 +1,4 @@
 endpoint: "http://s3.seagate.com"
+#admin_endpoint: "http://127.0.0.1:28049"
 s3_service_name: cortxs3
 s3_region: us-west2

--- a/s3/replication/manager/src/s3replicationmanager/prepare_job.py
+++ b/s3/replication/manager/src/s3replicationmanager/prepare_job.py
@@ -90,6 +90,9 @@ class PrepareReplicationJob:
             '%Y%m%dT%H%M%SZ')
 
         job_dict["source"]["endpoint"] = cortx_s3["endpoint"]
+
+        if "admin_endpoint" in cortx_s3:
+            job_dict["source"]["admin_endpoint"] = cortx_s3["admin_endpoint"]
         job_dict["source"]["service_name"] = cortx_s3["s3_service_name"]
         job_dict["source"]["region"] = cortx_s3["s3_region"]
 

--- a/s3/replication/replicator/src/s3replicator/object_replicator.py
+++ b/s3/replication/replicator/src/s3replicator/object_replicator.py
@@ -54,9 +54,10 @@ class ObjectReplicator:
             self._range_read_offset,
             self._range_read_length)
 
-        self._object_status = S3AsyncUpdatereplicationStatus(
+        self._source_replication_status = S3AsyncUpdatereplicationStatus(
             self._s3_source_session,
             self._request_id,
+            job.get_source_owner_account_id(),
             job.get_source_bucket_name(),
             job.get_source_object_name())
 
@@ -108,7 +109,7 @@ class ObjectReplicator:
                 await observer.notify(JobEvents.COMPLETED, self._job_id)
 
         if JobEvents.COMPLETED:
-            await self._object_status.update('COMPLETED')
+            await self._source_replication_status.update('COMPLETED')
 
             source_etag = self._object_source_reader.get_etag()
             target_etag = self._object_writer.get_etag()


### PR DESCRIPTION
Adds support for using CORTX S3 server's internal admin API (currently used by background delete) to update `x-amz-replication-status` after replicating an object. Since there is no normal S3 API to do this, we need to use this non-standard mechanism. At the moment, the special background delete service account must be used for this feature. As such, this PR does not enable metadata update by default to avoid breaking everything (at least until service accounts are figured out). Uncomment the new `admin_endpoint` config entry to enable this feature. If used with a replication-capable S3 server (currently on a separate branch), the new status should show up in the `head-object` output.

For EOS-26795

Signed-off-by: Tim Shaffer <tim.shaffer@seagate.com>

# Problem Statement
- Problem statement

# Design
-  For Bug, Describe the fix here.
-  For Feature, Post the link for design

# Coding
   Checklist for Author
-  [ ] Coding conventions are followed and code is consistent

# Testing 
  Checklist for Author
- [ ] Unit and System Tests are added
- [ ] Test Cases cover Happy Path, Non-Happy Path and Scalability
- [ ] Testing was performed with RPM

# Impact Analysis
  Checklist for Author/Reviewer/GateKeeper
- [ ] Interface change (if any) are documented
- [ ] Side effects on other features (deployment/upgrade)
- [ ] Dependencies on other component(s)

# Review Checklist 
  Checklist for Author
- [ ] JIRA number/GitHub Issue added to PR
- [ ] PR is self reviewed
- [ ] Jira and state/status is updated and JIRA is updated with PR link
- [ ] Check if the description is clear and explained

# Documentation
  Checklist for Author
- [ ] Changes done to WIKI / Confluence page / Quick Start Guide
